### PR TITLE
Fix broken tests and linux node build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Run tests
+on:
+  pull_request:
+    paths:
+      - '*.js'
+      - '*.ts'
+      - '*.vue'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          npm ci
+
+      - name: Run tests
+        run: |
+          npm run test:unit
+
+      - name: Lint and push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm run lint
+
+          # exit if nothing has changed
+          [[ `git status --porcelain` ]] || exit
+
+          git checkout "${GITHUB_HEAD_REF}"
+
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git add .
+          git commit -am "lint: automated linter"
+          git push -u origin ${GITHUB_HEAD_REF}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "translate-helper",
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -61,8 +61,9 @@
       All data are stored locally, using browser's local storage for page. No
       data is being sent or uploaded anywhere, there's no tracking on the site.
       All code is available open source
-      <a href="https://github.com/asmnh/translate-helper" target="_blank">on Github</a>,
-      including build process.
+      <a href="https://github.com/asmnh/translate-helper" target="_blank"
+        >on Github</a
+      >, including build process.
     </p>
   </div>
 </template>

--- a/src/views/Translations.vue
+++ b/src/views/Translations.vue
@@ -120,12 +120,15 @@ export default defineComponent({
       await state.translations.connect();
       const filename = await getFilename();
       const href = `data:text/plain;charset=utf-8,${getDataEncoded()}`;
-      fileDownload.value?.setAttribute("href", href);
-      fileDownload.value?.setAttribute("download", filename);
-      await fileDownload.value?.click();
-      await nextTick();
-      fileDownload.value?.setAttribute("href", "");
-      fileDownload.value?.setAttribute("download", "");
+      if (fileDownload.value) {
+        const downloadElem = fileDownload.value;
+        downloadElem.setAttribute("href", href);
+        downloadElem.setAttribute("download", filename);
+        await downloadElem.click();
+        await nextTick();
+        downloadElem.setAttribute("href", "");
+        downloadElem.setAttribute("download", "");
+      }
     };
 
     const clear = () => {

--- a/tests/unit/state/settings.spec.ts
+++ b/tests/unit/state/settings.spec.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from "chai";
 import spies from "chai-spies";
-import Settings from "@/state/settings";
+import Settings, { SettingsData } from "@/state/settings";
 import { SETTINGS_STORAGE_KEY } from "@/state/store";
 
 chai.use(spies);
@@ -17,8 +17,12 @@ describe("state/settings.ts", () => {
     const newSettings = {
       languages: ["en", "ja", "kr", "fr"],
       translationFilename: "some{name}.csv",
-      translationTemplate: "{lang}.{key}:{value}",
-    };
+      translationTemplate: {
+        prefix: "",
+        suffix: "",
+        each: "{lang}.{key}:{value}",
+      },
+    } as SettingsData;
 
     const storageSpy = chai.spy.on(localStorage, "setItem");
 
@@ -35,7 +39,11 @@ describe("state/settings.ts", () => {
   it("updates stored settings on update", () => {
     const languages = ["en", "ja", "kr", "fr"];
     const translationFilename = "some{name}.csv";
-    const translationTemplate = "{lang}.{key}:{value}";
+    const translationTemplate = {
+      prefix: "",
+      suffix: "",
+      each: "{lang}.{key}:{value}",
+    };
 
     const localStorage = {
       getItem: () => null,
@@ -53,7 +61,7 @@ describe("state/settings.ts", () => {
 
     expect(settings.languages).to.include.members(languages);
     expect(settings.translationFilename).to.be.eq(translationFilename);
-    expect(settings.translationTemplate).to.be.eq(translationTemplate);
+    expect(settings.translationTemplate).to.be.eql(translationTemplate);
   });
 
   it("loads from global store on refresh", () => {


### PR DESCRIPTION
Fixes unit tests broken when changing settings structure (file template changed from single string to triplet of prefix/each/suffix).

Changed how `fileDownload` access behaves to stop node from throwing up errors.

Adds running tests as a build step for merges to important branches and for pull requests.