### PR TITLE
Change when CodeQL is running

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - dist
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
+    paths:
+      - '*.js'
+      - '*.ts'
+      - '*.vue'
   schedule:
     - cron: '26 0 * * 4'
 


### PR DESCRIPTION
Run CodeQL on both main and dist branches (dist since it's where all the compiled JS ends up), and whenever a PR touches anything that contains js.