### PR TITLE
Check for conflicts against external translations JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "vue-router": "^4.0.0-0"
       },
       "devDependencies": {
+        "@types/axios": "^0.14.0",
         "@types/chai": "^4.2.11",
         "@types/chai-spies": "^1.0.3",
         "@types/mocha": "^5.2.4",
@@ -32,6 +33,7 @@
         "@vue/eslint-config-prettier": "^6.0.0",
         "@vue/eslint-config-typescript": "^7.0.0",
         "@vue/test-utils": "^2.0.0-0",
+        "axios-mock-adapter": "^1.19.0",
         "chai": "^4.1.2",
         "chai-spies": "^1.0.0",
         "chai-spy": "^0.0.1",
@@ -1569,6 +1571,16 @@
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
       "dev": true
+    },
+    "node_modules/@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
+      "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
+      "dev": true,
+      "dependencies": {
+        "axios": "*"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.0",
@@ -3800,6 +3812,19 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dependencies": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "node_modules/axios-mock-adapter": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.3"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.9.0"
       }
     },
     "node_modules/babel-code-frame": {
@@ -19378,6 +19403,15 @@
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
       "dev": true
     },
+    "@types/axios": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
+      "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
+      "dev": true,
+      "requires": {
+        "axios": "*"
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -21161,6 +21195,16 @@
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
+      }
+    },
+    "axios-mock-adapter": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.3"
       }
     },
     "babel-code-frame": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vue-router": "^4.0.0-0"
   },
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/chai": "^4.2.11",
     "@types/chai-spies": "^1.0.3",
     "@types/mocha": "^5.2.4",
@@ -34,6 +35,7 @@
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/eslint-config-typescript": "^7.0.0",
     "@vue/test-utils": "^2.0.0-0",
+    "axios-mock-adapter": "^1.19.0",
     "chai": "^4.1.2",
     "chai-spies": "^1.0.0",
     "chai-spy": "^0.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,34 @@
   <router-view />
 </template>
 
+<script lang="ts">
+import State from "@/state";
+import { defineComponent, inject } from "vue";
+
+export default defineComponent({
+  setup() {
+    const state = inject("state") as State;
+    return { state };
+  },
+  mounted() {
+    this.backgroundDownloadTranslations();
+  },
+  methods: {
+    async backgroundDownloadTranslations() {
+      try {
+        if (this.state.settings.translationsSourceUri) {
+          await this.state.translations.existing.download(
+            this.state.settings.translationsSourceUri
+          );
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    },
+  },
+});
+</script>
+
 <style lang="scss">
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -11,6 +11,7 @@ export interface SettingsData {
   translationTemplate: TranslationTemplate;
   translationFilename: string;
   languages: string[];
+  translationsSourceUri?: string;
 }
 
 export function defaultSettings(): SettingsData {
@@ -50,6 +51,10 @@ export default class Settings {
     return this._data.translationFilename;
   }
 
+  get translationsSourceUri(): string | null {
+    return this._data.translationsSourceUri || null;
+  }
+
   update(data: SettingsData): void {
     this._storage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(data));
     this._data.translationTemplate.prefix = data.translationTemplate.prefix;
@@ -57,5 +62,6 @@ export default class Settings {
     this._data.translationTemplate.each = data.translationTemplate.each;
     this._data.translationFilename = data.translationFilename;
     this._data.languages = data.languages;
+    this._data.translationsSourceUri = data.translationsSourceUri;
   }
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,5 +1,6 @@
 export const SETTINGS_STORAGE_KEY = "translate-helper-settings";
 export const TRANSLATIONS_STORAGE_KEY = "translate-helper-values";
+export const EXISTING_TRANSLATIONS_BUFFER = "translate-existing-buffer";
 
 const setItem = (key: string, data: string): void => {
   window.localStorage.setItem(key, data);

--- a/src/state/translation-tree.ts
+++ b/src/state/translation-tree.ts
@@ -85,11 +85,14 @@ export default class TranslationTree {
   async download(uri: string): Promise<TranslationTree> {
     try {
       this.isDownloading.value = true;
-      const data = (await axios.get(uri)).data as TranslationNode;
-      this.tree = data;
+      const data = (await axios.get(uri)).data;
+      if (typeof data === "string") {
+        throw new Error("Unable to parse translations as string");
+      }
+      this.tree = data as TranslationNode;
       this.hasDownloadedData.value = true;
       this.isDownloading.value = false;
-      this.downloadCallbacks.forEach((cb) => cb(data));
+      this.downloadCallbacks.forEach((cb) => cb(this.tree));
     } catch (err) {
       this.hasDownloadedData.value = false;
       this.isDownloading.value = false;

--- a/src/state/translation-tree.ts
+++ b/src/state/translation-tree.ts
@@ -1,0 +1,53 @@
+export interface TranslationNode {
+  [key: string]: TranslationNode | string | null;
+}
+
+export default class TranslationTree {
+  private tree: TranslationNode;
+
+  constructor(tree: TranslationNode) {
+    this.tree = tree;
+  }
+
+  get keys(): string[] {
+    const recurseKeys = function (
+      keys: string[],
+      node: TranslationNode | string | null
+    ): string[] {
+      if (!node) {
+        return [];
+      } else if (typeof node === "string") {
+        return [keys.join(".")];
+      } else {
+        return Object.entries(node).flatMap(([key, value]) =>
+          recurseKeys([...keys, key], value)
+        );
+      }
+    };
+    return recurseKeys([], this.tree);
+  }
+
+  get all(): TranslationNode {
+    return this.tree;
+  }
+
+  // returns false when path conflicts with existing keys, otherwise true
+  allowsKey(key: string): boolean {
+    const parts = key.split(".");
+    let cursor = this.tree;
+
+    while (parts.length > 0) {
+      const next = cursor[parts[0]];
+      if (!next) {
+        return true;
+      }
+      if (typeof next === "string") {
+        return parts.length === 1;
+      } else {
+        parts.shift();
+        cursor = next;
+      }
+    }
+    return false;
+  }
+}

--- a/src/state/translations.ts
+++ b/src/state/translations.ts
@@ -32,6 +32,13 @@ export default class Translations {
       storage.getItem(EXISTING_TRANSLATIONS_BUFFER) || "{}"
     ) as TranslationNode;
     this._existing = new TranslationTree(translations);
+    this._existing.onDownload(function (tree: TranslationNode) {
+      storage.setItem(EXISTING_TRANSLATIONS_BUFFER, JSON.stringify(tree));
+    });
+  }
+
+  get existing(): TranslationTree {
+    return this._existing;
   }
 
   get values(): TT[] {

--- a/src/state/translations.ts
+++ b/src/state/translations.ts
@@ -1,5 +1,10 @@
 import { reactive, ref, Ref } from "vue";
-import { LocalStorageType, TRANSLATIONS_STORAGE_KEY } from "./store";
+import {
+  EXISTING_TRANSLATIONS_BUFFER,
+  LocalStorageType,
+  TRANSLATIONS_STORAGE_KEY,
+} from "./store";
+import TranslationTree, { TranslationNode } from "./translation-tree";
 
 export interface TT {
   key: string;
@@ -12,6 +17,8 @@ export default class Translations {
   private _pending: Promise<void> | null;
   private _saving: Ref<boolean>;
 
+  private _existing: TranslationTree;
+
   constructor(storage: LocalStorageType) {
     this._storage = storage;
     const data = JSON.parse(
@@ -20,6 +27,11 @@ export default class Translations {
     this._values = reactive(data);
     this._pending = null;
     this._saving = ref(false);
+
+    const translations = JSON.parse(
+      storage.getItem(EXISTING_TRANSLATIONS_BUFFER) || "{}"
+    ) as TranslationNode;
+    this._existing = new TranslationTree(translations);
   }
 
   get values(): TT[] {

--- a/tests/unit/state/translation-tree.spec.ts
+++ b/tests/unit/state/translation-tree.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "chai";
 import TranslationTree from "@/state/translation-tree";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 
 describe("state/translation-tree.ts", () => {
   const testData = {
@@ -58,5 +60,26 @@ describe("state/translation-tree.ts", () => {
     expect(subject.allowsKey("secondflat")).to.be.true;
     expect(subject.allowsKey("element.inner.path.to.very.deep.value")).to.be
       .true;
+  });
+
+  it("loads translations from url", async () => {
+    const translationUri = "https://some.uri/translations";
+    const mock = new MockAdapter(axios);
+    mock.onGet(translationUri).reply(200, testData);
+
+    const subject = new TranslationTree({});
+    await subject.download(translationUri);
+
+    const expected = [
+      "element.value1",
+      "element.value2",
+      "element.value3",
+      "element.inner.element",
+      "other.value",
+      "flat",
+    ];
+
+    expect(subject.keys).to.include.members(expected);
+    expect(subject.keys.length).to.be.eq(expected.length);
   });
 });

--- a/tests/unit/state/translation-tree.spec.ts
+++ b/tests/unit/state/translation-tree.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+import TranslationTree from "@/state/translation-tree";
+
+describe("state/translation-tree.ts", () => {
+  const testData = {
+    element: {
+      value1: "text",
+      value2: "more text",
+      value3: "even more",
+      inner: {
+        element: "thing",
+      },
+    },
+    other: {
+      value: "element",
+    },
+    flat: "text",
+  };
+
+  it("provides valid flat key list from translations dictionary", () => {
+    const subject = new TranslationTree(testData);
+
+    const result = subject.keys;
+
+    const expected = [
+      "element.value1",
+      "element.value2",
+      "element.value3",
+      "element.inner.element",
+      "other.value",
+      "flat",
+    ];
+
+    expect(result).to.include.members(expected);
+    expect(result.length).to.be.eq(expected.length);
+  });
+
+  it("disallows keys in middle of the tree", () => {
+    const subject = new TranslationTree(testData);
+
+    expect(subject.allowsKey("element")).to.be.false;
+    expect(subject.allowsKey("element.inner")).to.be.false;
+  });
+
+  it("allows keys that are overwriting existing nodes", () => {
+    const subject = new TranslationTree(testData);
+
+    expect(subject.allowsKey("element.value1")).to.be.true;
+    expect(subject.allowsKey("element.inner.element")).to.be.true;
+    expect(subject.allowsKey("flat")).to.be.true;
+  });
+
+  it("allows valid nonexistent keys to be added", () => {
+    const subject = new TranslationTree(testData);
+
+    expect(subject.allowsKey("element.newvalue")).to.be.true;
+    expect(subject.allowsKey("other.element.value")).to.be.true;
+    expect(subject.allowsKey("secondflat")).to.be.true;
+    expect(subject.allowsKey("element.inner.path.to.very.deep.value")).to.be
+      .true;
+  });
+});


### PR DESCRIPTION
Adds support for downloading external translations and checking against translation tree for conflicting entries.

An entry is considered conflicting if trying to add it would overwrite a JSON object node with string. Overwriting existing translations or adding new paths inside the tree is allowed.

Also fixes marking conflicting entries if new translation conflicts with another already existing. There is no visual distinction on what kind of conflict it is, but given expected use with just handful of new keys at one time, this should not be a problem.

closes #2 