### PR TITLE
Documentation and project description cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,35 @@
 # Translate helper
 
-Standalone vue3 app - scratchbook for translation and permission list to deal with later on.
-
 [Hosted web](https://asmnh.github.io/translate-helper/#/)
 
-## Project setup
-```
-npm install
-```
+Standalone vue3 app - scratchbook for translation and permission list to deal with later on.
 
-### Compiles and hot-reloads for development
-```
-npm run serve
-```
+For development info see [Development](docs/development.md).
 
-### Compiles and minifies for production
-```
-npm run build
-```
+## Status
 
-### Run your unit tests
-```
-npm run test:unit
-```
+| Check | Status |
+|-------|--------|
+| Deploy | [![Build and Deploy](https://github.com/asmnh/translate-helper/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/asmnh/translate-helper/actions/workflows/deploy.yml) |
+| CodeQL | [![CodeQL](https://github.com/asmnh/translate-helper/actions/workflows/codeql-analysis.yml/badge.svg?branch=main)](https://github.com/asmnh/translate-helper/actions/workflows/codeql-analysis.yml) |
+| Tests | [![Run tests](https://github.com/asmnh/translate-helper/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/asmnh/translate-helper/actions/workflows/test.yml) |
 
-### Lints and fixes files
-```
-npm run lint
-```
+## What it does
 
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+It's a simple standalone application to help keeping track of added translation strings as you work on something, to make preparing translations changelist easier.
+
+It supports arbitrary set of languages, assumes all translations are in form of JSON tree, and includes checking against potential tree conflict (when newly added key would conflict with existing one, by either overwriting text with tree node, or tree node with text). For conflict checks, you can provide external JSON URL that will be automatically loaded every time you open the app.
+
+Exporting translations uses whatever format you prefer (see: Settings tab), which was intended to support CSV, SQL scripts (database inserts/updates) and potentially code snippet generation.
+
+## Project goals
+
+It's mostly my attempt at getting more familiar with frontend development, Vue.js and Typescript/Javascript. Don't expect this project to be anything clean and pristine, and probably you don't want to use it as an example of how good Vue.js project should look.
+
+Functionally, it's supposed to be a second-screen tool to keep while working, to handle things such as translations, permissions (assuming key-based on/off permission system) and various other things that need to either be reconstructed when closing a task, or kept track of as you work.
+
+Everything here is kept local browser only, meaning it doesn't require internet connection to work, and doesn't raise any security concerns that go beyond keeping your browser safe. Whatever remote communication there is (for now: requesting existing translations), it's kept as pull-only, and doesn't send *any* data entered into the app *anywhere* at all.
+
+## Contributing
+
+Any ideas, issues, and pull requests are welcome.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,35 @@
+# Development and testing
+
+## Automatic checks
+
+All pull requests are checked in regards of unit tests, CodeQL analysis and overall syntax. Linter is applied automatically on every pull request, but commits are still expected to be properly linted.
+
+As of now there is no code coverage check, and tests are somewhat incomplete - to be fixed later.
+
+## Project setup
+```
+npm install
+```
+
+### Compiles and hot-reloads for development
+```
+npm run serve
+```
+
+### Compiles and minifies for production
+```
+npm run build
+```
+
+### Run your unit tests
+```
+npm run test:unit
+```
+
+### Lints and fixes files
+```
+npm run lint
+```
+
+### Customize configuration
+See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -36,6 +36,14 @@
         <pre>{value}</pre>
         for translated text.
       </li>
+      <li>
+        <strong>Translation sources</strong> - optional, URL to translations
+        JSON (a JSON that keeps translations as JSON object, with dot-path
+        allowing to access nodes/leafs), to check whether newly added
+        translations conflict with existing ones. Downloaded translations are
+        cached locally in browser, and are refreshed every time you load page or
+        save settings.
+      </li>
     </ul>
     <h2>Usage</h2>
     <p>


### PR DESCRIPTION
* Redacted README to be more reader-friendly.
* Moved vue default project manual to `docs/development.md`, added link in README
* Added missing option description - translation sources